### PR TITLE
Add Netlify build config to `netlify.toml`

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,3 @@
+[build]
+  publish = "public"
+  command = "npm run build"


### PR DESCRIPTION
Because there is no default build configuration, using the `Deploy to Netlify` button results in a successful build that serves an empty website. 

I have added a `netlify.toml` to provide Netlify with the right build config based on the recommended [Common configuration directives](https://www.netlify.com/docs/continuous-deployment/#common-configuration-directives)

I have tried to build my website with this configuration and now it works 👍 

Thank you for this awesome Starter. I am going to be using it as my personal wiki pages and I really love it.