### PR TITLE
add config for trailing slash

### DIFF
--- a/config.js
+++ b/config.js
@@ -2,7 +2,8 @@ const config = {
 	"gatsby": {
 		"pathPrefix": "/",
 		"siteUrl": "https://learn.hasura.io",
-		"gaTrackingId": null
+		"gaTrackingId": null,
+		"trailingSlash": false
 	},
 	"header": {
 		"logo": "https://graphql-engine-cdn.hasura.io/learn-hasura/assets/homepage/favicon.png",
@@ -24,11 +25,11 @@ const config = {
 	},
 	"sidebar": {
 		"forcedNavOrder": [
-			"/introduction",
+			"/introduction", // add trailing slash if enabled above
     		"/codeblock"
 		],
     	"collapsedNav": [
-      		"/codeblock"
+      		"/codeblock" // add trailing slash if enabled above
     	],
 		"links": [
 			{ "text": "Hasura", "link": "https://hasura.io"},

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -11,7 +11,6 @@ const plugins = [
     }
   },
   'gatsby-plugin-emotion',
-  'gatsby-plugin-remove-trailing-slashes',
   'gatsby-plugin-react-helmet',
   {
     resolve: "gatsby-source-filesystem",
@@ -77,6 +76,12 @@ if (config.pwa && config.pwa.enabled && config.pwa.manifest) {
 } else {
   plugins.push('gatsby-plugin-remove-serviceworker');
 }
+
+// check and remove trailing slash
+if (config.gatsby && !config.gatsby.trailingSlash) {
+  plugins.push('gatsby-plugin-remove-trailing-slashes');
+}
+
 module.exports = {
   pathPrefix: config.gatsby.pathPrefix,
   siteMetadata: {

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,6 +1,7 @@
 const componentWithMDXScope = require("gatsby-plugin-mdx/component-with-mdx-scope");
 const path = require("path");
 const startCase = require("lodash.startcase");
+const config = require("./config");
 
 exports.createPages = ({ graphql, actions }) => {
   const { createPage } = actions;
@@ -74,11 +75,19 @@ exports.onCreateNode = ({ node, getNode, actions }) => {
       value = "";
     }
 
-    createNodeField({
-      name: `slug`,
-      node,
-      value: `/${value}`
-    });
+    if(config.gatsby && config.gatsby.trailingSlash) {
+      createNodeField({
+        name: `slug`,
+        node,
+        value: value === "" ? `/` : `/${value}/`
+      });
+    } else {
+      createNodeField({
+        name: `slug`,
+        node,
+        value: `/${value}`
+      });
+    }
 
     createNodeField({
       name: "id",

--- a/src/components/rightSidebar.js
+++ b/src/components/rightSidebar.js
@@ -5,8 +5,6 @@ import Link from "./link";
 import './styles.css';
 import config from '../../config';
 
-const forcedNavOrder = config.sidebar.forcedNavOrder;
-
 const Sidebar = styled('aside')`
   width: 100%;
   background-color: #fff;

--- a/src/components/sidebar/index.js
+++ b/src/components/sidebar/index.js
@@ -6,8 +6,6 @@ import {ExternalLink} from "react-feather";
 import '../styles.css';
 import config from '../../../config';
 
-const forcedNavOrder = config.sidebar.forcedNavOrder;
-
 // eslint-disable-next-line no-unused-vars
 const ListItem = styled(({ className, active, level, ...props }) => {
     return (

--- a/src/components/sidebar/treeNode.js
+++ b/src/components/sidebar/treeNode.js
@@ -39,9 +39,9 @@ const TreeNode = ({className = '', setCollapsed, collapsed, url, title, items, .
 
       {!isCollapsed && hasChildren ? (
         <ul>
-          {items.map((item) => (
+          {items.map((item, index) => (
             <TreeNode
-              key={item.url}
+              key={item.url + index.toString()}
               setCollapsed={setCollapsed}
               collapsed={collapsed}
               {...item}

--- a/src/templates/docs.js
+++ b/src/templates/docs.js
@@ -61,7 +61,10 @@ export default class MDXRuntimeTest extends Component {
             return { ...acc, [cur]: [cur] };
           }
 
-          const prefix = cur.split("/")[1];
+          let prefix = cur.split("/")[1];
+          if(config.gatsby && config.gatsby.trailingSlash) {
+            prefix = prefix + '/';
+          }
 
           if (prefix && forcedNavOrder.find(url => url === `/${prefix}`)) {
             return { ...acc, [`/${prefix}`]: [...acc[`/${prefix}`], cur] };


### PR DESCRIPTION
Gatsby enforces trailing slash by default. The plugin`gatsby-plugin-remove-trailing-slashes` makes a redirect to remove the slash. 
This PR adds an optional config to enforce trailing slash, the default gatsby behaviour.

The default behaviour for this starter before (and still) was to apply the plugin to remove the trailing slash. Now this PR makes it configurable to opt in for trailing slash.

