### PR TITLE
'<filename>' -> '/<filename>'

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Open `config.js` for templating variables. Broadly configuration is available fo
     - `search` - Enable search and [configure Algolia](https://www.gatsbyjs.org/docs/adding-search-with-algolia/)
 
 - `sidebar` config for navigation links configuration
-    - `forcedNavOrder` for left sidebar navigation order. It should be in the format "/<filename>"
+    - `forcedNavOrder` for left sidebar navigation order. It should be in the format "/\<filename>"
     - `frontLine` - whether to show a front line at the beginning of a nested menu.(Collapsing capability would be turned of if this option is set to true)
     - `links` - Links on the bottom left of the sidebar
     - `ignoreIndex` - Set this to true if the index.md file shouldn't appear on the left sidebar navigation. Typically this can be used for landing pages.


### PR DESCRIPTION
'\<filename>' is not a html tag, but regarded as
by markdown interpreters because of the 'less
than' and 'greater than' characters.