### PR TITLE
Fix to allow non-md pages to render correctly

### DIFF
--- a/src/templates/docs.js
+++ b/src/templates/docs.js
@@ -15,7 +15,7 @@ export default class MDXRuntimeTest extends Component {
     const { data } = this.props;
 
     if (!data) {
-      return null;
+      return this.props.children;
     }
     const {
       allMdx,


### PR DESCRIPTION
Gatsby-gitbook-starter uses 'gatsby-plugin-layout' to drape ./src/templates/docs.js overtop of all the pages on the site. This creates an issue where if a user tries to create a page using either exports.createPages or by adding a file to src/pages (as described here https://www.gatsbyjs.com/docs/recipes/pages-layouts/) the page will just render as empty because this function returns null.

You can see that a user reported this issue here https://github.com/hasura/gatsby-gitbook-starter/issues/55