### PR TITLE
center the previous/next arrow vertically

### DIFF
--- a/src/components/styles/PageNavigationButtons.js
+++ b/src/components/styles/PageNavigationButtons.js
@@ -65,7 +65,7 @@ export const StyledNextPrevious = styled('div')`
   }
 
   .leftArrow {
-    display: block;
+    display: flex;
     margin: 0px;
     color: rgb(157, 170, 182);
     flex: 0 0 auto;
@@ -76,12 +76,12 @@ export const StyledNextPrevious = styled('div')`
   }
 
   .rightArrow {
+    display: flex;
     flex: 0 0 auto;
     font-size: 24px;
     transition: color 200ms ease 0s;
     padding: 16px;
     padding-left: 16px;
-    display: block;
     margin: 0px;
     color: rgb(157, 170, 182);
   }


### PR DESCRIPTION
The previous/next arrow was not centered vertically. This PR fix it using `display: flex`.
`align-items: center` is inherited from `.previousBtn` or `.nextBtn`.
![difference of arrow position before and after modification](https://user-images.githubusercontent.com/48012204/100210660-93e2c900-2f4e-11eb-9899-ade387a4faf2.png)
