### PR TITLE
Changed to allow code other than javascript in CodeBlock

### DIFF
--- a/src/components/mdxComponents/codeBlock.js
+++ b/src/components/mdxComponents/codeBlock.js
@@ -30,7 +30,7 @@ const CodeBlock = ({ children: exampleCode, ...props }) => {
     return <LoadableComponent code={exampleCode} />;
   } else {
     return (
-      <Highlight {...defaultProps} code={exampleCode} language="javascript" theme={prismTheme}>
+      <Highlight {...defaultProps} code={exampleCode} language={props.className.split("-")[1] ?? "javascript"} theme={prismTheme}>
         {({ className, style, tokens, getLineProps, getTokenProps }) => (
           <pre className={className + ' pre'} style={style} p={3}>
             {cleanTokens(tokens).map((line, i) => {


### PR DESCRIPTION
Currently, the code is forced to javascript. Modify other languages ​​so that they are correctly highlighted.
