### PR TITLE
make sidebar child elements collapsed as default

### DIFF
--- a/src/components/sidebar/tree.js
+++ b/src/components/sidebar/tree.js
@@ -125,10 +125,15 @@ const Tree = ({ edges }) => {
   treeData.items.forEach(item => {
     if (config.sidebar.collapsedNav && config.sidebar.collapsedNav.includes(item.url)) {
       defaultCollapsed[item.url] = true;
+      if (item.items.length !== 0) { // Assume page has children that should be collapsed
+      item.items.forEach(child => {
+        defaultCollapsed[child.url] = true;
+      })}
     } else {
       defaultCollapsed[item.url] = false;
     }
   });
+  
   const [collapsed, setCollapsed] = useState(defaultCollapsed);
 
   const toggle = url => {


### PR DESCRIPTION
if sidebar menu has submenu make it collapased as default 
you can add sidebar menu as collapsed in config.js

ex : 
collapsedNav: [
      '/books', // add trailing slash if enabled above
      '/algorithm',
      '/algorithm/child',
    ],