### PR TITLE
experiment: update mdx parser to accept custom ids on multi lingual translations

### DIFF
--- a/src/components/mdxComponents/index.js
+++ b/src/components/mdxComponents/index.js
@@ -4,24 +4,32 @@ import CodeBlock from './codeBlock';
 import AnchorTag from './anchor';
 import '../styles.css';
 
+const parseId = (content) => {
+  const [text, id] = content.split("{#");
+  if (!!text && !!id) {
+    return [text, id.replace('}', '').replace(/\s+/g, '').toLowerCase()]
+  }
+  return [content, content.replace(/\s+/g, '').toLowerCase()]
+}
+
 export default {
   h1: (props) => (
-    <h1 className="heading1" id={props.children.replace(/\s+/g, '').toLowerCase()} {...props} />
+    <h1 className="heading1" id={parseId(props.children)[1]} {...props}>{parseId(props.children)[0]}</h1>
   ),
-  h2: (props) => (
-    <h2 className="heading2" id={props.children.replace(/\s+/g, '').toLowerCase()} {...props} />
+  h2: (props) => console.log({props}) || (
+    <h2 className="heading2" id={parseId(props.children)[1]} {...props}>{parseId(props.children)[0]}</h2>
   ),
   h3: (props) => (
-    <h3 className="heading3" id={props.children.replace(/\s+/g, '').toLowerCase()} {...props} />
+    <h3 className="heading3" id={parseId(props.children)[1]} {...props}>{parseId(props.children)[0]}</h3>
   ),
   h4: (props) => (
-    <h4 className="heading4" id={props.children.replace(/\s+/g, '').toLowerCase()} {...props} />
+    <h4 className="heading4" id={parseId(props.children)[1]} {...props}>{parseId(props.children)[0]}</h4>
   ),
   h5: (props) => (
-    <h5 className="heading5" id={props.children.replace(/\s+/g, '').toLowerCase()} {...props} />
+    <h5 className="heading5" id={parseId(props.children)[1]} {...props}>{parseId(props.children)[0]}</h5>
   ),
   h6: (props) => (
-    <h6 className="heading6" id={props.children.replace(/\s+/g, '').toLowerCase()} {...props} />
+    <h6 className="heading6" id={parseId(props.children)[1]} {...props}>{parseId(props.children)[0]}</h6>
   ),
   p: (props) => <p className="paragraph" {...props} />,
   pre: (props) => <pre className="pre" {...props} />,

--- a/src/components/mdxComponents/index.js
+++ b/src/components/mdxComponents/index.js
@@ -2,34 +2,27 @@
 import React from 'react';
 import CodeBlock from './codeBlock';
 import AnchorTag from './anchor';
+import { customIdParser } from '../../utils/customIdParser';
 import '../styles.css';
-
-const parseId = (content) => {
-  const [text, id] = content.split("{#");
-  if (!!text && !!id) {
-    return [text, id.replace('}', '').replace(/\s+/g, '').toLowerCase()]
-  }
-  return [content, content.replace(/\s+/g, '').toLowerCase()]
-}
 
 export default {
   h1: (props) => (
-    <h1 className="heading1" id={parseId(props.children)[1]} {...props}>{parseId(props.children)[0]}</h1>
+    <h1 className="heading1" id={customIdParser(props.children).id} {...props}>{customIdParser(props.children).content}</h1>
   ),
-  h2: (props) => console.log({props}) || (
-    <h2 className="heading2" id={parseId(props.children)[1]} {...props}>{parseId(props.children)[0]}</h2>
+  h2: (props) => (
+    <h2 className="heading2" id={customIdParser(props.children).id} {...props}>{customIdParser(props.children).content}</h2>
   ),
   h3: (props) => (
-    <h3 className="heading3" id={parseId(props.children)[1]} {...props}>{parseId(props.children)[0]}</h3>
+    <h3 className="heading3" id={customIdParser(props.children).id} {...props}>{customIdParser(props.children).content}</h3>
   ),
   h4: (props) => (
-    <h4 className="heading4" id={parseId(props.children)[1]} {...props}>{parseId(props.children)[0]}</h4>
+    <h4 className="heading4" id={customIdParser(props.children).id} {...props}>{customIdParser(props.children).content}</h4>
   ),
   h5: (props) => (
-    <h5 className="heading5" id={parseId(props.children)[1]} {...props}>{parseId(props.children)[0]}</h5>
+    <h5 className="heading5" id={customIdParser(props.children).id} {...props}>{customIdParser(props.children).content}</h5>
   ),
   h6: (props) => (
-    <h6 className="heading6" id={parseId(props.children)[1]} {...props}>{parseId(props.children)[0]}</h6>
+    <h6 className="heading6" id={customIdParser(props.children).id} {...props}>{customIdParser(props.children).content}</h6>
   ),
   p: (props) => <p className="paragraph" {...props} />,
   pre: (props) => <pre className="pre" {...props} />,

--- a/src/components/rightSidebar.js
+++ b/src/components/rightSidebar.js
@@ -79,13 +79,6 @@ const SidebarLayout = ({ location }) => (
     `}
     render={({ allMdx }) => {
       let finalNavItems;
-      const parseId = (content) => {
-        const [text, id] = content.split("{#");
-        if (!!text && !!id) {
-          return [text, id.replace('}', '').replace(/\s+/g, '').toLowerCase()]
-        }
-        return [content, content.replace(/\s+/g, '').toLowerCase()]
-      }
 
       if (allMdx.edges !== undefined && allMdx.edges.length > 0) {
         allMdx.edges.map((item) => {

--- a/src/components/rightSidebar.js
+++ b/src/components/rightSidebar.js
@@ -3,6 +3,7 @@ import { StaticQuery, graphql } from 'gatsby';
 import styled from '@emotion/styled';
 import './styles.css';
 import config from '../../config';
+import { customIdParser } from '../utils/customIdParser';
 
 const Sidebar = styled('aside')`
   width: 100%;
@@ -97,13 +98,15 @@ const SidebarLayout = ({ location }) => (
             ) {
               if (item.node.tableOfContents.items) {
                 innerItems = item.node.tableOfContents.items.map((innerItem, index) => {
+                  const idParsedContent = customIdParser(innerItem.title);
+
                   const itemId = innerItem.title
-                    ? parseId(innerItem.title)[1]
+                    ? idParsedContent.id
                     : '#';
 
                   return (
                     <ListItem key={index} to={`#${itemId}`} level={1}>
-                      {parseId(innerItem.title)[0]}
+                      {idParsedContent.content}
                     </ListItem>
                   );
                 });

--- a/src/components/rightSidebar.js
+++ b/src/components/rightSidebar.js
@@ -78,6 +78,13 @@ const SidebarLayout = ({ location }) => (
     `}
     render={({ allMdx }) => {
       let finalNavItems;
+      const parseId = (content) => {
+        const [text, id] = content.split("{#");
+        if (!!text && !!id) {
+          return [text, id.replace('}', '').replace(/\s+/g, '').toLowerCase()]
+        }
+        return [content, content.replace(/\s+/g, '').toLowerCase()]
+      }
 
       if (allMdx.edges !== undefined && allMdx.edges.length > 0) {
         allMdx.edges.map((item) => {
@@ -91,12 +98,12 @@ const SidebarLayout = ({ location }) => (
               if (item.node.tableOfContents.items) {
                 innerItems = item.node.tableOfContents.items.map((innerItem, index) => {
                   const itemId = innerItem.title
-                    ? innerItem.title.replace(/\s+/g, '').toLowerCase()
+                    ? parseId(innerItem.title)[1]
                     : '#';
 
                   return (
                     <ListItem key={index} to={`#${itemId}`} level={1}>
-                      {innerItem.title}
+                      {parseId(innerItem.title)[0]}
                     </ListItem>
                   );
                 });

--- a/src/utils/customIdParser.js
+++ b/src/utils/customIdParser.js
@@ -1,5 +1,5 @@
 // Parses the custom added it to keep the url hash un-affected irrespective of translation
-// This is a hot-fix that relies on syntax
+// This is a hot-fix that relies on syntax and works only for headers (# h1 to ###### h6)
 // Ex: ## GraphQL Mutations Title can be in any language {#graphql-mutations}
 // The custom id should be enclosed with in `{#id-in-english}` in english.
 export const customIdParser = (content) => {

--- a/src/utils/customIdParser.js
+++ b/src/utils/customIdParser.js
@@ -1,3 +1,7 @@
+// Parses the custom added it to keep the url hash un-affected irrespective of translation
+// This is a hot-fix that relies on syntax
+// Ex: ## GraphQL Mutations Title can be in any language {#graphql-mutations}
+// The custom id should be enclosed with in `{#id-in-english}` in english.
 export const customIdParser = (content) => {
   const [text, id] = content.split("{#");
   if (!!text && !!id) {

--- a/src/utils/customIdParser.js
+++ b/src/utils/customIdParser.js
@@ -1,0 +1,14 @@
+export const customIdParser = (content) => {
+  const [text, id] = content.split("{#");
+  if (!!text && !!id) {
+    return {
+      content: text,
+      id: id.replace('}', '').replace(/\s+/g, '').toLowerCase()
+    }
+  }
+
+  return {
+    content,
+    id: content.replace(/\s+/g, '').toLowerCase()
+  }
+}


### PR DESCRIPTION
Use below format in MDX files for header tags to have custom ids (english) on translated files

Fixes URL translation (URL should be in english).

[Heading Ids](https://www.markdownguide.org/extended-syntax/#heading-ids)

```
### My Great Heading IN Other Language {#custom-id-in-english}
```

The HTML looks like this:
```
<h3 id="custom-id-in-english">My Great Heading IN Other Language</h3>
```

Note: this is experimental and need proper testing before considering as a fix.
