### PR TITLE
add: cloud office hours registration link

### DIFF
--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -85,7 +85,7 @@ const Footer = ({location}) => {
             <div className="footerLinks hasura-ibm-plex-nav">
               <div className="footerLinksHeader">Resources</div>
               <a href={`https://hasura.io/blog/`} className="links" target="_blank" rel="noopener noreferrer">Blog</a>
-              <a href="https://hasura.io/user-stories/" className="links">User Stories</a>
+              <a href="https://hasura.io/case-studies/" className="links">case Studies</a>
               <a href="https://3factor.app/" className="links" target="_blank" rel="noopener noreferrer">3Factor Apps</a>
               <a href="https://hasura.io/event-driven-programming/" className="links">Event Driven Programming</a>
               <a href="https://hasura.io/react-graphql/" className="links">React GraphQL</a>

--- a/src/components/navproduct.scss
+++ b/src/components/navproduct.scss
@@ -91,8 +91,11 @@
           margin-left: 6px;
           width: 8px;
           display: inline-block;
+
           img {
             min-width: 8px;
+            margin-left: 8px;
+            margin-bottom: -5px;
           }
         }
       }

--- a/src/components/resourcesnav.js
+++ b/src/components/resourcesnav.js
@@ -29,9 +29,9 @@ const navListState = [
   },
   {
     imgSrc: userstudiesIcon,
-    title: 'User stories',
+    title: 'Case Studies',
     desc: 'Read user case-studies',
-    linkUrl: 'https://hasura.io/user-stories/',
+    linkUrl: 'https://hasura.io/case-studies/',
     externalLink: true,
   },
   {
@@ -133,16 +133,21 @@ const ResourcesNav = () => {
                 </div>
               </div>
             </a>
-            <a href='https://hasura.io/graphql/database/'>
-              <div className='navListAnnouncement navDataBaseBg'>
-                <div className='hasura-ibm-plex-article-desc'>
-                  Supported Databases
-                  <div className='arrow'>
-                    <img src={arrowWhite} alt='Arrow' />
+            <a
+              href="https://us02web.zoom.us/meeting/register/tZUvduuspzksGdXb_Kp2u8cNJQQ5JGxXVOrg"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <div className="navListAnnouncement navDataBaseBg">
+                <div className="hasura-ibm-plex-article-desc">
+                  Hasura Cloud Office Hours
+                  <div className="arrow">
+                    <img src={arrowWhite} alt="Arrow" />
                   </div>
                 </div>
-                <div className='hasura-ibm-plex-mono'>
-                  Auto-generate GraphQL & REST APIs for your data from any of our supported dbs
+                <div className="hasura-ibm-plex-mono">
+                  Join us for Hasura Cloud office hours in October. Every Wednesday at 9:30am PT/
+                  12:30 pm ET.
                 </div>
               </div>
             </a>


### PR DESCRIPTION
- Added cloud office hours registration link in header (resource) 

<img width="455" alt="Screenshot 2021-10-13 at 2 25 11 PM" src="https://user-images.githubusercontent.com/6664187/137101022-b18ee4a9-53b8-464d-908a-12b55a086eca.png">

- Updated `User Stories` redirects navigation links to `/case-studies`


