### PR TITLE
Add support for relative links in markdown

### DIFF
--- a/content/index.mdx
+++ b/content/index.mdx
@@ -2,7 +2,7 @@
 title: "Landing Page"
 ---
 
-Some introduction text. Lists out all the headings from h1 to h6. Easy to customise. Some more text. Additional text.
+Some introduction text. Lists out all the headings from h1 to h6. Markdown link handling for relative and absolute URLs. Easy to customise.
 
 # Heading H1
 Heading 1 text
@@ -28,3 +28,8 @@ Heading 6 text
 - Item 3
 - Item 4
 - Item 5
+
+## Links
+
+* Relative: [Codeblock](/codeblock)
+* Absolute: [Demo](https://learn.hasura.io/graphql/react)

--- a/content/introduction.md
+++ b/content/introduction.md
@@ -4,7 +4,7 @@ metaTitle: "This is the title tag of this page"
 metaDescription: "This is the meta description"
 ---
 
-Some introduction text. Lists out all the headings from h1 to h6. Easy to customise.
+Some introduction text. Lists out all the headings from h1 to h6. Markdown link handling for relative and absolute URLs. Easy to customise.
 
 # Heading H1
 Heading 1 text
@@ -30,3 +30,8 @@ Heading 6 text
 - Item 3
 - Item 4
 - Item 5
+
+## Links
+
+* Relative: [Codeblock](/codeblock)
+* Absolute: [Demo](https://learn.hasura.io/graphql/react)

--- a/src/components/mdxComponents/anchor.js
+++ b/src/components/mdxComponents/anchor.js
@@ -1,12 +1,22 @@
 import * as React from 'react';
+import { Link as GatsbyLink } from 'gatsby';
+import isAbsoluteUrl from 'is-absolute-url';
 
 const AnchorTag = ({ children: link, ...props }) => {
   if (link) {
-    return (
-      <a href={props.href} target="_blank" rel="noopener noreferrer">
-        {link}
-      </a>
-    );
+    if (isAbsoluteUrl(props.href)) {
+      return (
+        <a href={props.href} target="_blank" rel="noopener noreferrer">
+          {link}
+        </a>
+      );
+    } else {
+      return (
+        <GatsbyLink to={props.href} {...props}>
+          {link}
+        </GatsbyLink>
+      );
+    }
   } else {
     return null;
   }


### PR DESCRIPTION
Add support for relative links in markdown files and include examples on the landing and intro pages.

Addresses #104