### PR TITLE
[#158] fix: added node option to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ FROM node:buster
 # Create app directory
 WORKDIR /app
 
+ENV NODE_OPTIONS=--openssl-legacy-provider
+
 # Install app dependencies
 # RUN npm -g install serve
 RUN npm -g install gatsby-cli


### PR DESCRIPTION
## Description

The following error occurred when building docker.

```
#12 7.451   Error: error:0308010C:digital envelope routines::unsupported
```
This is a node 17 problem.

The current docker file uses the latest node base image, so version 17 was used.

In order to use the latest version of node while using the latest version, you need to add the following environment variables to the dockerfile.

```
ENV NODE_OPTIONS=--openssl-legacy-provider
```
