### PR TITLE
Correct camelcasing for 'config.sidebar.frontLine'

### DIFF
--- a/config.js
+++ b/config.js
@@ -45,7 +45,7 @@ const config = {
       '/codeblock', // add trailing slash if enabled above
     ],
     links: [{ text: 'Hasura', link: 'https://hasura.io' }],
-    frontline: false,
+    frontLine: false,
     ignoreIndex: true,
     title:
       "<a href='https://hasura.io/learn/'>graphql </a><div class='greenCircle'></div><a href='https://hasura.io/learn/graphql/react/introduction/'>react</a>",


### PR DESCRIPTION
The 'frontline' (all lower-case) variable in the config was referenced as 'frontLine' in the component code. Making it camelCased in config.js corrects the issue.