### PR TITLE
UI: Move feedback and edit components and update css

### DIFF
--- a/src/components/styles.css
+++ b/src/components/styles.css
@@ -1037,7 +1037,8 @@ strong {
   font-weight: 600;
 }
 .pre {
-  font-size: 14px;
+  font-size: 16px;
+  line-height: 1.5;
   margin: 0px;
   padding: 0;
   margin-bottom: 32px;

--- a/src/templates/docs.js
+++ b/src/templates/docs.js
@@ -6,14 +6,14 @@ import styled from '@emotion/styled';
 import { Layout, Link } from '../components';
 import NextPrevious from '../components/NextPrevious';
 import SubHeader from '../components/SubHeader';
-import UseHasuraFree from "../components/UseHasuraFree";
-import CopyWriter from "../components/CopyWriter";
+import UseHasuraFree from '../components/UseHasuraFree';
+import CopyWriter from '../components/CopyWriter';
 // import FloatingSubscribeNewsletter from '../components/FloatingSubscribeNewsletter';
 import '../components/styles.css';
 import config from '../../config';
 import gitHub from '../components/images/github.svg';
 import footerIllustration from '../components/images/footer-img.png';
-import hasuraConDark from "../components/images/hasura-con-dark.svg";
+import hasuraConDark from '../components/images/hasura-con-dark.svg';
 import { saTrack } from '../utils/segmentAnalytics';
 
 const forcedNavOrder = config.sidebar.forcedNavOrder;
@@ -25,13 +25,13 @@ const Edit = styled('div')`
     text-align: right;
 
     a {
-      font-family: "IBM Plex Sans";
+      font-family: 'IBM Plex Sans';
       font-style: normal;
       font-weight: 300;
       font-size: 16px;
       line-height: 160%;
       text-decoration: none;
-      color: #1B2738;
+      color: #1b2738;
 
       /* border: 1px solid rgb(211, 220, 228); */
       cursor: pointer;
@@ -46,7 +46,7 @@ const Edit = styled('div')`
       .arrow {
         margin-left: 6px;
         display: flex;
-        transition: all .3s ease-in-out;
+        transition: all 0.3s ease-in-out;
       }
       &:hover {
         /* background-color: rgb(245, 247, 249); */
@@ -65,7 +65,7 @@ const Edit = styled('div')`
   @media (min-width: 768px) and (max-width: 1199px) {
     padding-top: 0;
   }
-  @media(max-width: 767px) {
+  @media (max-width: 767px) {
     .editOnGithub {
       justify-content: center;
       padding-top: 24px;
@@ -87,7 +87,7 @@ const BreadCrumbHeader = styled('div')`
   @media (max-width: 1200px) {
     display: block;
   }
-  @media(max-width: 767px) {
+  @media (max-width: 767px) {
     display: block;
   }
 `;
@@ -106,18 +106,19 @@ const HelpfulGithubWrapper = styled('div')`
     .iconWrapper {
       display: flex;
       align-items: center;
-      .satisfied, .dissatisfied {
+      .satisfied,
+      .dissatisfied {
         margin: 0 8px;
         display: flex;
         cursor: pointer;
         position: relative;
         &:hover {
           svg {
-            fill: #0079BD;
+            fill: #0079bd;
           }
         }
         svg {
-          fill: #74818A;
+          fill: #74818a;
         }
         .toolTip {
           background-color: #000;
@@ -135,7 +136,7 @@ const HelpfulGithubWrapper = styled('div')`
       }
       .active {
         svg {
-          fill: #0079BD;
+          fill: #0079bd;
         }
       }
     }
@@ -146,7 +147,7 @@ const HelpfulGithubWrapper = styled('div')`
       padding-bottom: 12px;
     }
   }
-  @media(max-width: 767px) {
+  @media (max-width: 767px) {
     display: block;
     .helpfulWrapper {
       display: block;
@@ -168,16 +169,21 @@ const FooterImag = styled('div')`
 
 const ArrowRight = () => (
   <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <path fillRule="evenodd" clipRule="evenodd" d="M7.63611 11.9698C7.34322 12.2627 7.34322 12.7375 7.63611 13.0304C7.92901 13.3233 8.40388 13.3233 8.69677 13.0304L13.1968 8.53038C13.4897 8.23748 13.4897 7.76261 13.1968 7.46971L8.69677 2.96967C8.40388 2.67678 7.92901 2.67678 7.63611 2.96967C7.34322 3.26256 7.34322 3.73744 7.63611 4.03033L10.8558 7.25L2.99982 7.25C2.5856 7.25 2.24982 7.58579 2.24982 8C2.24982 8.41422 2.5856 8.75 2.99982 8.75L10.8559 8.75L7.63611 11.9698Z" fill="#1B2738"/>
+    <path
+      fillRule="evenodd"
+      clipRule="evenodd"
+      d="M7.63611 11.9698C7.34322 12.2627 7.34322 12.7375 7.63611 13.0304C7.92901 13.3233 8.40388 13.3233 8.69677 13.0304L13.1968 8.53038C13.4897 8.23748 13.4897 7.76261 13.1968 7.46971L8.69677 2.96967C8.40388 2.67678 7.92901 2.67678 7.63611 2.96967C7.34322 3.26256 7.34322 3.73744 7.63611 4.03033L10.8558 7.25L2.99982 7.25C2.5856 7.25 2.24982 7.58579 2.24982 8C2.24982 8.41422 2.5856 8.75 2.99982 8.75L10.8559 8.75L7.63611 11.9698Z"
+      fill="#1B2738"
+    />
   </svg>
-)
+);
 
-const EditGithubBtn = ({docsLocation, parentRelativePath, cNmae}) => (
+const EditGithubBtn = ({ docsLocation, parentRelativePath, cNmae }) => (
   <Edit>
-    <div className={"editOnGithub" + ((cNmae) ? " alignLeft" : "")}>
+    <div className={'editOnGithub' + (cNmae ? ' alignLeft' : '')}>
       {docsLocation && (
         <Link className="gitBtn" to={`${docsLocation}/${parentRelativePath}`} target="_blank">
-          <img src={gitHub} alt='Github logo' /> Edit on GitHub
+          <img src={gitHub} alt="Github logo" /> Edit on GitHub
           <div className="arrow">
             <ArrowRight />
           </div>
@@ -185,10 +191,10 @@ const EditGithubBtn = ({docsLocation, parentRelativePath, cNmae}) => (
       )}
     </div>
   </Edit>
-)
+);
 
-const StyledHsauraConBanner = styled(props => <Link {...props} />)`
-  background-color: #E7EBEF;
+const StyledHsauraConBanner = styled((props) => <Link {...props} />)`
+  background-color: #e7ebef;
   border-radius: 4px;
   padding: 32px;
   display: grid;
@@ -210,7 +216,7 @@ const StyledHsauraConBanner = styled(props => <Link {...props} />)`
     align-self: center;
   }
   .hasuraConDesc {
-    color: #23303D;
+    color: #23303d;
     font-weight: 600;
     font-size: 12px;
     padding-bottom: 8px;
@@ -221,23 +227,22 @@ const StyledHsauraConBanner = styled(props => <Link {...props} />)`
     font-weight: 500;
     font-size: 20px;
     line-height: 150%;
-    color: #23303D;
+    color: #23303d;
     padding-bottom: 16px;
   }
   .hasuraConRegister {
     font-weight: 600;
     font-size: 14px;
-    color: #23303D;
+    color: #23303d;
     display: flex;
     align-items: center;
     svg {
-      transition: all .3s ease-in-out;
+      transition: all 0.3s ease-in-out;
       margin-left: 6px;
     }
   }
   .hasuraConBrand {
     img {
-
     }
   }
   @keyframes up-right {
@@ -259,7 +264,7 @@ const StyledHsauraConBanner = styled(props => <Link {...props} />)`
     width: 8px;
     height: 8px;
     min-height: 8px;
-    background-color: #1DB789;
+    background-color: #1db789;
     border-radius: 50%;
     margin-right: 8px;
     -webkit-animation: up-right 1s infinite;
@@ -267,7 +272,7 @@ const StyledHsauraConBanner = styled(props => <Link {...props} />)`
     -o-animation: up-right 1s infinite;
     animation: up-right 1s infinite;
   }
-  @media(max-width: 1215px) {
+  @media (max-width: 1215px) {
     grid-template-columns: 1fr;
     grid-gap: 16px;
     padding: 24px;
@@ -280,7 +285,7 @@ const StyledHsauraConBanner = styled(props => <Link {...props} />)`
   }
 `;
 
-const HasuraConBanner = ({title, desc, link}) => (
+const HasuraConBanner = ({ title, desc, link }) => (
   <StyledHsauraConBanner to={link}>
     <div className="hasuraConBrand alignSelfCenter hasConMobileShow">
       <img src={hasuraConDark} alt="Hasura Con" />
@@ -289,9 +294,7 @@ const HasuraConBanner = ({title, desc, link}) => (
       <div className="hasuraConDesc">
         <div className="greenCircle" /> {desc}
       </div>
-      <div className="hasuraConTitle">
-        {title}
-      </div>
+      <div className="hasuraConTitle">{title}</div>
       <div className="hasuraConRegister">
         Register Now
         <ArrowRight />
@@ -301,7 +304,7 @@ const HasuraConBanner = ({title, desc, link}) => (
       <img src={hasuraConDark} alt="Hasura Con" />
     </div>
   </StyledHsauraConBanner>
-)
+);
 
 export default class MDXRuntimeTest extends Component {
   constructor(props) {
@@ -313,17 +316,20 @@ export default class MDXRuntimeTest extends Component {
   }
 
   handlePageHelpfulResponse = (response) => {
-    this.setState({
-      isSatisfied: response,
-      showTooltip: true,
-    }, () => {
-      saTrack("Responded to Did You Find This Page Helpful", {
-        response: response ? 'YES' : 'NO',
-        pageUrl: this.props.location.href,
-      });
-      setTimeout(() => this.setState({showTooltip: false}), 5000)
-    }
-  )}
+    this.setState(
+      {
+        isSatisfied: response,
+        showTooltip: true,
+      },
+      () => {
+        saTrack('Responded to Did You Find This Page Helpful', {
+          response: response ? 'YES' : 'NO',
+          pageUrl: this.props.location.href,
+        });
+        setTimeout(() => this.setState({ showTooltip: false }), 5000);
+      }
+    );
+  };
 
   render() {
     const { data, location } = this.props;
@@ -390,9 +396,7 @@ export default class MDXRuntimeTest extends Component {
 
     // frontmatter canonical takes precedence
     canonicalUrl = mdx.frontmatter.canonicalUrl ? mdx.frontmatter.canonicalUrl : canonicalUrl;
-    const showFeedback =()=> {
-
-    }
+    const showFeedback = () => {};
 
     // const getHasuraConBanner = () => {
     //   if(config.gatsby.pathPrefix === "/learn/graphql/hasura-auth-slack") {
@@ -445,8 +449,12 @@ export default class MDXRuntimeTest extends Component {
           <link rel="canonical" href={canonicalUrl} />
         </Helmet>
         <BreadCrumbHeader>
-          <SubHeader location={location} title={mdx.fields.title}/>
-          <EditGithubBtn cNmae="mobileAlign" docsLocation={docsLocation} parentRelativePath={mdx.parent.relativePath} />
+          <SubHeader location={location} title={mdx.fields.title} />
+          <EditGithubBtn
+            cNmae="mobileAlign"
+            docsLocation={docsLocation}
+            parentRelativePath={mdx.parent.relativePath}
+          />
         </BreadCrumbHeader>
         {/*getHasuraConBanner()*/}
         <div className="titleWrapper">
@@ -458,47 +466,64 @@ export default class MDXRuntimeTest extends Component {
           <FloatingSubscribeNewsletter title={mdx.fields.title} canonicalUrl={canonicalUrl} location={location} />
           */}
         </div>
+        <div className="addPaddTopBottom">
+          <NextPrevious mdx={mdx} nav={nav} />
+        </div>
         <HelpfulGithubWrapper>
           <div className="helpfulWrapper">
             <div className="desc">Did you find this page helpful?</div>
             <div className="iconWrapper">
-              <div className={"satisfied" + ((isSatisfied) ? " active" : "")}
-                onClick={()=> this.handlePageHelpfulResponse(true)}>
-                <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                  <path d="M15.5 11C16.3284 11 17 10.3284 17 9.5C17 8.67157 16.3284 8 15.5 8C14.6716 8 14 8.67157 14 9.5C14 10.3284 14.6716 11 15.5 11Z"/>
-                  <path d="M8.5 11C9.32843 11 10 10.3284 10 9.5C10 8.67157 9.32843 8 8.5 8C7.67157 8 7 8.67157 7 9.5C7 10.3284 7.67157 11 8.5 11Z"/>
-                  <path d="M15.5 11C16.3284 11 17 10.3284 17 9.5C17 8.67157 16.3284 8 15.5 8C14.6716 8 14 8.67157 14 9.5C14 10.3284 14.6716 11 15.5 11Z"/>
-                  <path d="M8.5 11C9.32843 11 10 10.3284 10 9.5C10 8.67157 9.32843 8 8.5 8C7.67157 8 7 8.67157 7 9.5C7 10.3284 7.67157 11 8.5 11Z"/>
-                  <path d="M11.99 2C6.47 2 2 6.48 2 12C2 17.52 6.47 22 11.99 22C17.52 22 22 17.52 22 12C22 6.48 17.52 2 11.99 2ZM12 20C7.58 20 4 16.42 4 12C4 7.58 7.58 4 12 4C16.42 4 20 7.58 20 12C20 16.42 16.42 20 12 20ZM12 17.5C14.33 17.5 16.32 16.05 17.12 14H15.45C14.76 15.19 13.48 16 12 16C10.52 16 9.25 15.19 8.55 14H6.88C7.68 16.05 9.67 17.5 12 17.5Z"/>
+              <div
+                className={'satisfied' + (isSatisfied ? ' active' : '')}
+                onClick={() => this.handlePageHelpfulResponse(true)}
+              >
+                <svg
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path d="M15.5 11C16.3284 11 17 10.3284 17 9.5C17 8.67157 16.3284 8 15.5 8C14.6716 8 14 8.67157 14 9.5C14 10.3284 14.6716 11 15.5 11Z" />
+                  <path d="M8.5 11C9.32843 11 10 10.3284 10 9.5C10 8.67157 9.32843 8 8.5 8C7.67157 8 7 8.67157 7 9.5C7 10.3284 7.67157 11 8.5 11Z" />
+                  <path d="M15.5 11C16.3284 11 17 10.3284 17 9.5C17 8.67157 16.3284 8 15.5 8C14.6716 8 14 8.67157 14 9.5C14 10.3284 14.6716 11 15.5 11Z" />
+                  <path d="M8.5 11C9.32843 11 10 10.3284 10 9.5C10 8.67157 9.32843 8 8.5 8C7.67157 8 7 8.67157 7 9.5C7 10.3284 7.67157 11 8.5 11Z" />
+                  <path d="M11.99 2C6.47 2 2 6.48 2 12C2 17.52 6.47 22 11.99 22C17.52 22 22 17.52 22 12C22 6.48 17.52 2 11.99 2ZM12 20C7.58 20 4 16.42 4 12C4 7.58 7.58 4 12 4C16.42 4 20 7.58 20 12C20 16.42 16.42 20 12 20ZM12 17.5C14.33 17.5 16.32 16.05 17.12 14H15.45C14.76 15.19 13.48 16 12 16C10.52 16 9.25 15.19 8.55 14H6.88C7.68 16.05 9.67 17.5 12 17.5Z" />
                 </svg>
-                {
-                  showTooltip && isSatisfied ? (
-                    <div className="toolTip">Thanks for your feedback</div>
-                  ) : null
-                }
+                {showTooltip && isSatisfied ? (
+                  <div className="toolTip">Thanks for your feedback</div>
+                ) : null}
               </div>
-              <div className={"dissatisfied" + ((isSatisfied === false) ? " active" : "")} onClick={()=> this.handlePageHelpfulResponse(false)}>
-                <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                  <path d="M15.5 11C16.3284 11 17 10.3284 17 9.5C17 8.67157 16.3284 8 15.5 8C14.6716 8 14 8.67157 14 9.5C14 10.3284 14.6716 11 15.5 11Z"/>
-                  <path d="M8.5 11C9.32843 11 10 10.3284 10 9.5C10 8.67157 9.32843 8 8.5 8C7.67157 8 7 8.67157 7 9.5C7 10.3284 7.67157 11 8.5 11Z"/>
-                  <path d="M11.99 2C6.47 2 2 6.48 2 12C2 17.52 6.47 22 11.99 22C17.52 22 22 17.52 22 12C22 6.48 17.52 2 11.99 2ZM12 20C7.58 20 4 16.42 4 12C4 7.58 7.58 4 12 4C16.42 4 20 7.58 20 12C20 16.42 16.42 20 12 20ZM12 14C9.67 14 7.68 15.45 6.88 17.5H8.55C9.24 16.31 10.52 15.5 12 15.5C13.48 15.5 14.75 16.31 15.45 17.5H17.12C16.32 15.45 14.33 14 12 14Z"/>
+              <div
+                className={'dissatisfied' + (isSatisfied === false ? ' active' : '')}
+                onClick={() => this.handlePageHelpfulResponse(false)}
+              >
+                <svg
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path d="M15.5 11C16.3284 11 17 10.3284 17 9.5C17 8.67157 16.3284 8 15.5 8C14.6716 8 14 8.67157 14 9.5C14 10.3284 14.6716 11 15.5 11Z" />
+                  <path d="M8.5 11C9.32843 11 10 10.3284 10 9.5C10 8.67157 9.32843 8 8.5 8C7.67157 8 7 8.67157 7 9.5C7 10.3284 7.67157 11 8.5 11Z" />
+                  <path d="M11.99 2C6.47 2 2 6.48 2 12C2 17.52 6.47 22 11.99 22C17.52 22 22 17.52 22 12C22 6.48 17.52 2 11.99 2ZM12 20C7.58 20 4 16.42 4 12C4 7.58 7.58 4 12 4C16.42 4 20 7.58 20 12C20 16.42 16.42 20 12 20ZM12 14C9.67 14 7.68 15.45 6.88 17.5H8.55C9.24 16.31 10.52 15.5 12 15.5C13.48 15.5 14.75 16.31 15.45 17.5H17.12C16.32 15.45 14.33 14 12 14Z" />
                 </svg>
-                {
-                  showTooltip && isSatisfied !== null && !isSatisfied ? (
-                    <div className="toolTip">Thanks for your feedback</div>
-                  ) : null
-                }
+                {showTooltip && isSatisfied !== null && !isSatisfied ? (
+                  <div className="toolTip">Thanks for your feedback</div>
+                ) : null}
               </div>
             </div>
           </div>
           <EditGithubBtn docsLocation={docsLocation} parentRelativePath={mdx.parent.relativePath} />
         </HelpfulGithubWrapper>
-        <div className="addPaddTopBottom">
-          <NextPrevious mdx={mdx} nav={nav} />
-        </div>
         <UseHasuraFree />
         <FooterImag>
-          <img loading="lazy" src="https://graphql-engine-cdn.hasura.io/learn-hasura/assets/footer-img.png" alt='footer illustration' />
+          <img
+            loading="lazy"
+            src="https://graphql-engine-cdn.hasura.io/learn-hasura/assets/footer-img.png"
+            alt="footer illustration"
+          />
         </FooterImag>
         <CopyWriter />
       </Layout>
@@ -507,7 +532,7 @@ export default class MDXRuntimeTest extends Component {
 }
 
 export const pageQuery = graphql`
-  query($id: String!) {
+  query ($id: String!) {
     site {
       siteMetadata {
         title

--- a/src/templates/docs.js
+++ b/src/templates/docs.js
@@ -68,7 +68,7 @@ const Edit = styled('div')`
   @media (max-width: 767px) {
     .editOnGithub {
       justify-content: center;
-      padding-top: 24px;
+      padding-top: 16px;
       .arrow {
         display: inline-block;
       }
@@ -95,7 +95,7 @@ const BreadCrumbHeader = styled('div')`
 const HelpfulGithubWrapper = styled('div')`
   display: flex;
   justify-content: space-between;
-  padding-top: 14px;
+  padding-bottom: 40px;
   .helpfulWrapper {
     display: flex;
     align-items: center;


### PR DESCRIPTION
After feedback, this PR moves the navigation components directly under the end of a page's content by moving the feedback and GitHub components down. Additionally, the CSS is modified for `pre` elements to have a larger font size and greater line-height for increased readability.

**NB: Prettier also nicked a fair amount of content.**