### PR TITLE
Update banner

### DIFF
--- a/src/components/AnnouncementBanner/index.js
+++ b/src/components/AnnouncementBanner/index.js
@@ -117,10 +117,16 @@ export const AnnouncementBanner = () => {
                     alt="Icon"
                   />
                 )}
-                <div className="" fontWeight="font_bold">
+                <div className="">
                   {/* <div className="greenCircle pinkCircle" /> */}
                   <span className="displayInline">
-                    {bannerData?.bannerTitle}
+                    <p>
+                      <b>
+                        With the Hasura Data Delivery Network now GA, these courses are now
+                        out-of-date and considered deprecated.
+                      </b>{' '}
+                      Learn more about Hasura DDN.
+                    </p>
                     <span className="mobile-arrow-text">&nbsp;&gt;</span>
                   </span>
                 </div>


### PR DESCRIPTION
Updates the banner to have a unique message for hasura.io/learn.

As a stop-gap measure, we're letting users know the courses here are deprecated and out-of-date. As it appeared this content is accessed via an API, this simply hardcodes a unique message for Learn.