### PR TITLE
Feat: Add MaintainedAdmonition component

### DIFF
--- a/config.js
+++ b/config.js
@@ -39,6 +39,8 @@ const config = {
     ogImage: null,
     docsLocation: 'https://github.com/hasura/gatsby-gitbook-boilerplate/tree/master/content',
     favicon: 'https://graphql-engine-cdn.hasura.io/img/hasura_icon_black.svg',
+    // When set to false, this will render the MaintainedAdmonition component on each page in a course
+    isMaintained: false,
   },
   pwa: {
     enabled: false, // disabling this will also remove the existing service worker.

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -152,6 +152,7 @@ module.exports = {
     tweetText: config.header.tweetText,
     headerLinks: config.header.links,
     siteUrl: config.gatsby.siteUrl,
+    isMaintained: config.siteMetadata.isMaintained ?? true,
   },
   plugins: plugins,
 };

--- a/src/components/MaintainedAdmonition/index.js
+++ b/src/components/MaintainedAdmonition/index.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import './styles.scss';
+
+const MaintainedAdmonition = () => {
+  return (
+    <div className="outdated-notice">
+      <p>
+        This course is no longer maintained and may be out-of-date. While it remains available for
+        reference, its content may not reflect the latest updates, best practices, or supported
+        features.
+      </p>
+    </div>
+  );
+};
+
+export default MaintainedAdmonition;

--- a/src/components/MaintainedAdmonition/styles.scss
+++ b/src/components/MaintainedAdmonition/styles.scss
@@ -1,0 +1,13 @@
+.outdated-notice {
+  background-color: #fff3cd;
+  border-left: 5px solid #ffa000;
+  color: #856404;
+  padding: 1rem;
+  margin: 1rem 0;
+  border-radius: 4px;
+  font-size: 1rem;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}

--- a/src/templates/docs.js
+++ b/src/templates/docs.js
@@ -15,6 +15,7 @@ import gitHub from '../components/images/github.svg';
 import footerIllustration from '../components/images/footer-img.png';
 import hasuraConDark from '../components/images/hasura-con-dark.svg';
 import { saTrack } from '../utils/segmentAnalytics';
+import MaintainedAdmonition from '../components/MaintainedAdmonition';
 
 const forcedNavOrder = config.sidebar.forcedNavOrder;
 
@@ -342,7 +343,7 @@ export default class MDXRuntimeTest extends Component {
       allMdx,
       mdx,
       site: {
-        siteMetadata: { docsLocation, title },
+        siteMetadata: { docsLocation, title, isMaintained },
       },
     } = data;
 
@@ -457,6 +458,7 @@ export default class MDXRuntimeTest extends Component {
           />
         </BreadCrumbHeader>
         {/*getHasuraConBanner()*/}
+        {!isMaintained && <MaintainedAdmonition />}
         <div className="titleWrapper">
           <h1 className="title">{mdx.fields.title}</h1>
         </div>
@@ -537,6 +539,7 @@ export const pageQuery = graphql`
       siteMetadata {
         title
         docsLocation
+        isMaintained
       }
     }
     mdx(fields: { id: { eq: $id } }) {


### PR DESCRIPTION
## Description

Adds MaintainedAdmonition component to allow configuring a conditional render which warns users that a particular course may be unmaintained and out-of-date.

This can be set in the `config.js` for any course using `siteMetadata.isMaintained`; setting it to false will render the admonition while setting it to true — or omitting it — will result in the component not being visible.

## Example

<img width="1071" alt="Screenshot 2025-02-17 at 11 06 16 AM" src="https://github.com/user-attachments/assets/2da812e0-76d3-41a1-81f1-d70d2ab890f9" />
